### PR TITLE
Onxp 750 need to correct display of successful operation notification

### DIFF
--- a/src/components/notification.js
+++ b/src/components/notification.js
@@ -25,7 +25,8 @@ export function closeNotification(key) {
 export function showTimeoutNotification() {
 	return showNotification({
 		type: "info",
-		msg:
+		msg: "Timeout Error",
+		desc:
 			"Your transaction has not completed in time. This does not mean it necessary failed. Check result later",
 	});
 }

--- a/src/pages/send-asset/index.js
+++ b/src/pages/send-asset/index.js
@@ -96,7 +96,8 @@ class SendAsset extends Component {
 				formActions.resetForm();
 				showNotification({
 					type: "success",
-					msg: `You have successfully sent ${values.amount} ${values.asset_symbol} to ${
+					msg: "Success",
+					desc: `You have successfully sent ${values.amount} ${values.asset_symbol} to ${
 						values.receiver_address
 					} address`,
 				});


### PR DESCRIPTION
[ONXP-750](https://scaddr.apriorit.com/jira/browse/ONXP-750)  Send][UI] Need to correct display of successful operation notification:

- Fixed problem with notification on successful send not fitting in notification box: used description field to move majority of text from notification header.
- Refactored timeout error notification: moved description text to description field