### PR TITLE
now clicking outside create account modal is not closing it, modal cl…

### DIFF
--- a/src/components/modals/Registration.js
+++ b/src/components/modals/Registration.js
@@ -92,6 +92,7 @@ class RegistrationModal extends Component {
 				footer={null}
 				className="registration-modal"
 				destroyOnClose={true}
+				maskClosable={false}
 			>
 				<Formik
 					onSubmit={this.handleFormSubmit}


### PR DESCRIPTION
ONXP-825 [Gideon][Registration][UI] Pop-up window must be closed only when click "Close":
Now clicking outside create account modal is not closing it, modal closes by cancel button only
