### PR TITLE
filtering requests by their status implemented

### DIFF
--- a/src/pages/admin-panel/requests/UserUpgradeRequests.js
+++ b/src/pages/admin-panel/requests/UserUpgradeRequests.js
@@ -114,15 +114,13 @@ class UserUpgradeRequests extends Component {
 		);
 	};
 
-	handleFilterStatusChange = (statuses, filters) => {
+	handleFilterStatusChange = statuses => {
 		this.setState(
 			{
 				statusFilters: statuses,
 			},
 			() => {
-				this.fetchRequests({
-					...filters,
-				});
+				this.fetchRequests();
 			}
 		);
 	};

--- a/src/pages/admin-panel/requests/UserUpgradeRequests.js
+++ b/src/pages/admin-panel/requests/UserUpgradeRequests.js
@@ -1,14 +1,29 @@
 import React, { Component } from "react";
-import { Table, Button, notification, message } from "antd";
+import { Table, Button, Select, Divider, notification, message } from "antd";
 import ReasonToRejectUpgradeModal from "../../../components/modals/admin/ReasonToRejectUpgrade";
 import { getRequests, upgradeUser, rejectRequest } from "../../../api/admin/user-upgrade";
 import { TimeoutError } from "promise-timeout";
+const { Option } = Select;
 
 const style = {
 	button: {
 		marginRight: 8,
 	},
 };
+
+const requestStatus = {
+	active: "opened",
+	refused: "refused",
+	accepted: "closed", // request completed successfully ?
+	deleted: "deleted",
+};
+const initialFilters = [requestStatus.active];
+const requestStatusSelectOptions = [];
+for (let status in requestStatus) {
+	if (requestStatus.hasOwnProperty(status)) {
+		requestStatusSelectOptions.push(<Option key={requestStatus[status]}>{status}</Option>);
+	}
+}
 
 class UserUpgradeRequests extends Component {
 	state = {
@@ -18,6 +33,7 @@ class UserUpgradeRequests extends Component {
 		fetchingRequests: false,
 		loadingUpgradeUser: false,
 		loadingDowngradeUser: false,
+		statusFilters: initialFilters,
 	};
 
 	componentDidMount = () => {
@@ -98,14 +114,27 @@ class UserUpgradeRequests extends Component {
 		);
 	};
 
+	handleFilterStatusChange = (statuses, filters) => {
+		this.setState(
+			{
+				statusFilters: statuses,
+			},
+			() => {
+				this.fetchRequests({
+					...filters,
+				});
+			}
+		);
+	};
+
 	async fetchRequests(opts = {}) {
 		try {
-			const { pagination } = this.state;
+			const { pagination, statusFilters } = this.state;
 
 			const params = {
 				pageSize: pagination.pageSize,
 				pageNum: pagination.current,
-				status: "opened",
+				status: statusFilters.join(","),
 				...opts,
 			};
 			this.setState({ fetchingRequests: true });
@@ -164,23 +193,32 @@ class UserUpgradeRequests extends Component {
 				render: res => (res ? res : "n/a"),
 			},
 			{
-				title: "Actions",
+				title: "Actions / Info",
 				dataIndex: "",
 				render: res => (
 					<>
-						<Button
-							type="primary"
-							onClick={() =>
-								this.handleUpgrade(res.user.wallet_addr, res.expected_position, res.id)
-							}
-							style={style.button}
-							loading={res.id === request_id && loadingUpgradeUser}
-						>
-							Confirm
-						</Button>
-						<Button type="danger" onClick={() => this.showModal(res.id)} style={style.button}>
-							Reject
-						</Button>
+						{res.status === requestStatus.active ? (
+							<>
+								<Button
+									type="primary"
+									onClick={() =>
+										this.handleUpgrade(res.user.wallet_addr, res.expected_position, res.id)
+									}
+									style={style.button}
+									loading={res.id === request_id && loadingUpgradeUser}
+								>
+									Confirm
+								</Button>
+								<Button type="danger" onClick={() => this.showModal(res.id)} style={style.button}>
+									Reject
+								</Button>
+							</>
+						) : (
+							""
+						)}
+						{res.status === requestStatus.accepted ? "Request accepted" : ""}
+						{res.status === requestStatus.refused ? "Refused with reason '" + res.reason + "'" : ""}
+						{res.status === requestStatus.deleted ? "Request deleted" : ""}
 					</>
 				),
 			},
@@ -188,6 +226,16 @@ class UserUpgradeRequests extends Component {
 
 		return (
 			<>
+				<Select
+					mode="multiple"
+					style={{ width: "100%" }}
+					placeholder="Filter requests: "
+					defaultValue={initialFilters}
+					onChange={this.handleFilterStatusChange}
+				>
+					{requestStatusSelectOptions}
+				</Select>
+				<Divider> </Divider>
 				<Table
 					columns={columns}
 					rowKey={requests => requests.id}


### PR DESCRIPTION
ONXP-936 [Sprint 5] Accounts upgrade requests - additional filtering:
- added filtering with multiple choices to accounts upgrade requests page
- only active requests are shown by default
- Actions column now contains confirm / reject buttons or info about request status, if it's not opened