### PR TITLE
changed display of asset price/asset table

### DIFF
--- a/src/pages/assets-exchange/index.js
+++ b/src/pages/assets-exchange/index.js
@@ -47,7 +47,6 @@ const assetsColumns = [
 		title: "Balance",
 		dataIndex: "balance",
 		key: "balance",
-		width: "9em",
 	},
 ];
 
@@ -630,7 +629,7 @@ class AssetsExchange extends Component {
 					</Row>
 					<Divider />
 					<Row gutter={48} className="exchange-tables">
-						<Col md={48} lg={24}>
+						<Col lg={24} xl={12}>
 							<Table
 								columns={assetsColumns}
 								dataSource={this.state.assetsData}


### PR DESCRIPTION
ONXP-1009 [Exchange][UI] Need to align exchange rates and balances:

- changed first 3 columns to fixed-width, last one has no width (only this way header and columns are correctly aligned)
- now table is not full-width on xl screen width