### PR TITLE
not displaying onyx cash as asset for sell if user is superagent

### DIFF
--- a/src/pages/assets-exchange/index.js
+++ b/src/pages/assets-exchange/index.js
@@ -100,7 +100,12 @@ class AssetsExchange extends Component {
 	}
 
 	getAssetsForSellData() {
-		return this.getAssetsForTypeData("sell");
+		const { user } = this.props;
+
+		let assetsForSell = this.getAssetsForTypeData("sell");
+		return user.role === roles.sa
+			? assetsForSell.filter(asset => asset.name !== onyxCashSymbol)
+			: assetsForSell;
 	}
 
 	fillAssetsData = async () => {


### PR DESCRIPTION
ONXP-895 [Exchange][UI] OnyxCash should not displayed in assets to sell list for superadmin:

- not displaying onyx cash as asset for sell if user is superagent