### PR TITLE
Bugfix

### DIFF
--- a/src/api/admin/users.js
+++ b/src/api/admin/users.js
@@ -82,7 +82,8 @@ export async function isBlockedUser(userAccountAddress) {
 	});
 
 	const res = await sendTrx(trx, true, false);
-	if (res.Result.Result === "") {
+
+	if (res.Result.Result === "00") {
 		return false;
 	}
 	return true;

--- a/src/api/constants.js
+++ b/src/api/constants.js
@@ -151,3 +151,5 @@ export const h24Mc = 24 * 60 * 60 * 1000;
 export const refreshBalanceEveryMsec = 30000;
 
 export const gasCompensatorTimeout = 30000;
+
+export const supportEmail = "support@onyxPay.co";

--- a/src/api/operation-messages.js
+++ b/src/api/operation-messages.js
@@ -52,33 +52,3 @@ export async function getMessages(params, requestType, fetchActive) {
 		return handleReqError(error);
 	}
 }
-
-export async function getMessagesForActiveRequests(params, requestType = "deposit") {
-	try {
-		const authHeaders = getAuthHeaders();
-		const { data } = await client.get(`operation-messages/${requestType}/active-requests`, {
-			headers: {
-				...authHeaders,
-			},
-			params,
-		});
-		return data;
-	} catch (error) {
-		return handleReqError(error);
-	}
-}
-
-export async function getMessagesForClosedRequests(params, requestType = "deposit") {
-	try {
-		const authHeaders = getAuthHeaders();
-		const { data } = await client.get(`operation-messages/${requestType}/close-requests`, {
-			headers: {
-				...authHeaders,
-			},
-			params,
-		});
-		return data;
-	} catch (error) {
-		return handleReqError(error);
-	}
-}

--- a/src/components/SupportLink.js
+++ b/src/components/SupportLink.js
@@ -1,0 +1,8 @@
+import React from "react";
+import { supportEmail } from "api/constants";
+
+const SupportLink = ({ linkText = "contact support" }) => {
+	return <a href={`mailto:${supportEmail}`}>{linkText}</a>;
+};
+
+export default SupportLink;

--- a/src/components/modals/ChoosePerformer/index.js
+++ b/src/components/modals/ChoosePerformer/index.js
@@ -12,6 +12,7 @@ import { convertAmountToStr } from "utils/number";
 import { handleBcError } from "api/network";
 import { disableRequest } from "redux/requests";
 import { roles } from "api/constants";
+import { formatUserRole } from "utils";
 const { Option } = Select;
 const { Text } = Typography;
 
@@ -71,7 +72,7 @@ class ChoosePerformer extends Component {
 				if (openedRequestData.type === "withdraw") {
 					showNotification({
 						type: "success",
-						msg: "You successfully chosen an agent",
+						msg: "You have successfully chosen the Agent",
 						desc:
 							"Next, you should wait until fiat money is coming, and then finalize the request by clicking on the 'Perform' button",
 					});
@@ -81,14 +82,18 @@ class ChoosePerformer extends Component {
 					if (splittedAssetSymbol[0] === "o") {
 						assetSymbol = splittedAssetSymbol.slice(1).join("");
 					}
+					const performerRole =
+						openedRequestData.type === "deposit"
+							? formatUserRole("agent")
+							: formatUserRole("superagent");
 
 					showNotification({
 						type: "success",
-						msg: "You successfully chosen an agent",
+						msg: `You have successfully chosen the ${performerRole}`,
 						desc: `Send ${convertAmountToStr(
 							openedRequestData.amount,
 							8
-						)} FIAT ${assetSymbol} to agent ${performer.firstName} ${
+						)} ${assetSymbol} or equivalent in FIAT to ${performerRole} ${performer.firstName} ${
 							performer.lastName
 						} settlement account or hand over the cash by hand`,
 					});

--- a/src/components/modals/ChoosePerformer/index.js
+++ b/src/components/modals/ChoosePerformer/index.js
@@ -184,6 +184,7 @@ class ChoosePerformer extends Component {
 				pageNum: pagination.current,
 				role: performer,
 				country: country,
+				status: "active",
 				...opts,
 			};
 

--- a/src/components/modals/wallet/ImportWalletModal.js
+++ b/src/components/modals/wallet/ImportWalletModal.js
@@ -126,7 +126,7 @@ class ImportWalletModal extends Component {
 				try {
 					const wallet = getWallet(JSON.parse(data)).toJsonObj();
 					this.setState({ uploadedWallet: wallet }, () => {
-						if (this.state.uploadedWallet.accounts.length === 1) {
+						if (this.state.uploadedWallet.accounts.length) {
 							setFieldValue(
 								"wallet_account_address",
 								this.state.uploadedWallet.accounts[0].address
@@ -270,11 +270,7 @@ class ImportWalletModal extends Component {
 															showSearch
 															name="wallet_account_address"
 															optionFilterProp="children"
-															value={
-																uploadedWallet && uploadedWallet.accounts.length === 1
-																	? uploadedWallet.accounts[0].address
-																	: values.wallet_account_address
-															}
+															value={values.wallet_account_address}
 															onChange={this.handleAccountChange(setFieldValue)}
 															filterOption={(input, option) =>
 																option.props.children.toLowerCase().indexOf(input.toLowerCase()) >=

--- a/src/components/paginated-list/OperationsWidget.js
+++ b/src/components/paginated-list/OperationsWidget.js
@@ -18,7 +18,7 @@ const operationHistoryColumns = [
 		render: operationType => (operationType ? checkOperationType(operationType) : "n/a"),
 	},
 	{
-		title: "Requestor",
+		title: "Initiator",
 		dataIndex: "sender",
 		key: "from",
 		render: sender => (sender ? sender.firstName + " " + sender.lastName : "n/a"),

--- a/src/components/paginated-list/OperationsWidget.js
+++ b/src/components/paginated-list/OperationsWidget.js
@@ -11,7 +11,7 @@ const operationHistoryColumns = [
 		render: operationType => (operationType ? operationType : "n/a"),
 	},
 	{
-		title: "Requester",
+		title: "Requestor",
 		dataIndex: "sender",
 		key: "from",
 		render: sender => (sender ? sender.firstName + " " + sender.lastName : "n/a"),

--- a/src/pages/deposit/index.js
+++ b/src/pages/deposit/index.js
@@ -197,7 +197,7 @@ class Deposit extends Component {
 													style={{ display: "block", margin: "-12px 0 12px 0" }}
 												>
 													{!activeRequestsError &&
-														"You will be able to send to the agent only chosen fiat currency"}
+														"Only selected fiat currency can be sent to the agent"}
 												</Text>
 											) : null}
 										</Col>

--- a/src/pages/requests/ActiveRequests.js
+++ b/src/pages/requests/ActiveRequests.js
@@ -176,12 +176,23 @@ class ActiveRequests extends Component {
 	performRequest = async requestId => {
 		// agent performs deposit and client withdraw request
 		try {
-			const { disableRequest } = this.props;
+			const { disableRequest, location, data } = this.props;
 			this.setState({ requestId, activeAction: aa.perform });
-			await performRequest(requestId);
+
+			// await performRequest(requestId);
+			const requestType = parseRequestType(location);
+			let msgText;
+			if (requestType === "deposit" || requestType === "buy_onyx_cash") {
+				const opRequest = data.items.find(req => req.request.requestId === requestId);
+				msgText = `Deposit was successful to customer ${opRequest.sender.firstName} ${
+					opRequest.sender.lastName
+				}`;
+			} else if (requestType === "withdraw") {
+				msgText = "Withdraw was successful";
+			}
 			showNotification({
 				type: "success",
-				msg: "You have performed the request",
+				msg: msgText,
 			});
 			disableRequest(requestId);
 		} catch (e) {

--- a/src/pages/requests/ActiveRequests.js
+++ b/src/pages/requests/ActiveRequests.js
@@ -193,17 +193,29 @@ class ActiveRequests extends Component {
 			});
 
 			if (requestType === "deposit" || requestType === "buy_onyx_cash") {
-				msgText = `Deposit was successful to ${opRequest.sender.firstName} ${
-					opRequest.sender.lastName
-				}'s account`;
+				if (opRequest.request && opRequest.sender) {
+					const { firstName, lastName } = opRequest.sender;
+					const { amount, asset } = opRequest.request;
+					msgText = `Congratulations! You have successfully deposited ${convertAmountToStr(
+						amount,
+						8
+					)} ${asset} to ${firstName} ${lastName}'s account`;
+				} else {
+					msgText = "Deposit was successful";
+				}
 			} else if (requestType === "withdraw") {
 				if (opRequest.maker) {
-					msgText = `Withdrawal of ${convertAmountToStr(opRequest.amount, 8)} ${
-						opRequest.asset
-					} from your account was successful`;
-				} else if (opRequest.sender) {
+					msgText = `Congratulations! You have successfully withdrawn ${convertAmountToStr(
+						opRequest.amount,
+						8
+					)} ${opRequest.asset} from your account`;
+				} else if (opRequest.sender && opRequest.request) {
 					const { firstName, lastName } = opRequest.sender;
-					msgText = `Withdrawal from ${firstName} ${lastName}'s account was successful`;
+					const { amount, asset } = opRequest.request;
+					msgText = `Withdrawal of ${convertAmountToStr(
+						amount,
+						8
+					)} ${asset} from ${firstName} ${lastName}'s account was successful`;
 				} else {
 					msgText = "Withdrawal was successful";
 				}

--- a/src/pages/requests/ActiveRequests.js
+++ b/src/pages/requests/ActiveRequests.js
@@ -179,7 +179,7 @@ class ActiveRequests extends Component {
 			const { disableRequest, location, data } = this.props;
 			this.setState({ requestId, activeAction: aa.perform });
 
-			// await performRequest(requestId);
+			await performRequest(requestId);
 			const requestType = parseRequestType(location);
 			let msgText;
 			if (requestType === "deposit" || requestType === "buy_onyx_cash") {

--- a/src/pages/requests/table/columns/renderInitiatorColumns.js
+++ b/src/pages/requests/table/columns/renderInitiatorColumns.js
@@ -8,6 +8,7 @@ import CancelRequest from "../../CancelRequest";
 import { aa } from "../../common";
 import { renderPerformBtn, isTimeUp } from "../index";
 import { styles } from "../../styles";
+import SupportLink from "components/SupportLink";
 
 function punishForCancelation(trxCreated, thresholdToPunishInHr) {
 	const timePassedMs = new Date().getTime() - new Date(trxCreated).getTime();
@@ -190,8 +191,9 @@ export default function renderInitiatorColumns({
 				title: "Actions",
 				render: (text, record, index) => {
 					if (record.statusCode === requestStatus.complained) {
-						return null;
+						return <SupportLink />;
 					}
+
 					if (record._isDisabled) return "n/a";
 
 					const isComplainActive =

--- a/src/pages/requests/table/columns/renderInitiatorColumns.js
+++ b/src/pages/requests/table/columns/renderInitiatorColumns.js
@@ -135,6 +135,9 @@ export default function renderInitiatorColumns({
 				dataIndex: "status",
 				render: (text, record, index) => {
 					if (record._isDisabled) return "wait...";
+					if (record.takerAddr && record.statusCode === requestStatus.choose) {
+						return "waiting for perform";
+					}
 					return record.status;
 				},
 			},

--- a/src/pages/requests/table/columns/renderInitiatorColumns.js
+++ b/src/pages/requests/table/columns/renderInitiatorColumns.js
@@ -2,7 +2,7 @@ import React from "react";
 import { Button, Popconfirm, Tooltip } from "antd";
 import { convertAmountToStr } from "utils/number";
 import { getLocalTime, getPerformerName, is24hOver, is12hOver } from "utils";
-import { h24Mc, operationMessageStatus } from "api/constants";
+import { h24Mc, operationMessageStatus, requestStatus } from "api/constants";
 import Countdown from "components/Countdown";
 import CancelRequest from "../../CancelRequest";
 import { aa } from "../../common";
@@ -189,7 +189,11 @@ export default function renderInitiatorColumns({
 			{
 				title: "Actions",
 				render: (text, record, index) => {
+					if (record.statusCode === requestStatus.complained) {
+						return null;
+					}
 					if (record._isDisabled) return "n/a";
+
 					const isComplainActive =
 						record.requestId === activeRequestId && activeAction === aa.complain;
 
@@ -247,7 +251,6 @@ export default function renderInitiatorColumns({
 							{/* Complain on request */}
 							{record.takerAddr &&
 								record.chooseTimestamp &&
-								record.status !== "complained" &&
 								!is24hOver(record.chooseTimestamp) &&
 								renderComplainButton(record, handleComplain, isComplainActive)}
 

--- a/src/pages/requests/table/columns/renderPerformerColumns.js
+++ b/src/pages/requests/table/columns/renderPerformerColumns.js
@@ -8,6 +8,7 @@ import { h24Mc } from "api/constants";
 import { aa } from "../../common";
 import { renderPerformBtn, isTimeUp } from "../index";
 import { styles } from "../../styles";
+import SupportLink from "components/SupportLink";
 
 function isAnotherPerformerSelected(record, walletAddress) {
 	if (
@@ -283,7 +284,7 @@ export default function renderPerformerColumns({
 					if (!record.request) {
 						return null;
 					} else if (record.request.statusCode === requestStatus.complained) {
-						return null;
+						return <SupportLink />;
 					}
 					if (record._isDisabled) return "n/a";
 

--- a/src/pages/requests/table/columns/renderPerformerColumns.js
+++ b/src/pages/requests/table/columns/renderPerformerColumns.js
@@ -211,6 +211,11 @@ export default function renderPerformerColumns({
 					if (record.request) {
 						if (isAnotherPerformerSelected(record, walletAddress)) {
 							return "request wasn't selected";
+						} else if (
+							record.request.takerAddr &&
+							record.request.statusCode === requestStatus.choose
+						) {
+							return "waiting for perform";
 						}
 						return record.request.status;
 					} else {

--- a/src/pages/requests/table/columns/renderPerformerColumns.js
+++ b/src/pages/requests/table/columns/renderPerformerColumns.js
@@ -130,6 +130,43 @@ function renderConfirmBtn(record, isConfirmActive, confirmRequest) {
 	return null;
 }
 
+function renderHideBtn(
+	record,
+	hideRequest,
+	requestsType,
+	walletAddress,
+	isConfirmActive,
+	isCancelAcceptedRequestActive
+) {
+	if (
+		(record.status !== "accepted" &&
+			record.request &&
+			record.request.statusCode !== requestStatus.choose) ||
+		(record.request &&
+			record.request.statusCode === requestStatus.choose &&
+			record.request.takerAddr !== walletAddress &&
+			requestsType === "withdraw")
+	) {
+		if (isConfirmActive || isCancelAcceptedRequestActive) {
+			return (
+				<Button type="danger" disabled={true}>
+					Hide
+				</Button>
+			);
+		} else {
+			return (
+				<Popconfirm
+					title="Sure to hide?"
+					onConfirm={() => hideRequest(record.id)} // messageId
+				>
+					<Button type="danger">Hide</Button>
+				</Popconfirm>
+			);
+		}
+	}
+	return null;
+}
+
 export default function renderPerformerColumns({
 	activeRequestId,
 	activeAction,
@@ -262,20 +299,15 @@ export default function renderPerformerColumns({
 					return (
 						<>
 							{renderConfirmBtn(record, isConfirmActive, confirmRequest)}
-							{record.status !== "accepted" &&
-								(isConfirmActive || isCancelAcceptedRequestActive ? (
-									<Button type="danger" disabled={true}>
-										Hide
-									</Button>
-								) : (
-									<Popconfirm
-										title="Sure to hide?"
-										onConfirm={() => hideRequest(record.id)} // messageId
-									>
-										<Button type="danger">Hide</Button>
-									</Popconfirm>
-								))}
 
+							{renderHideBtn(
+								record,
+								hideRequest,
+								requestsType,
+								walletAddress,
+								isConfirmActive,
+								isCancelAcceptedRequestActive
+							)}
 							{renderPerformBtn(
 								record,
 								performRequest,

--- a/src/pages/requests/table/columns/renderPerformerColumns.js
+++ b/src/pages/requests/table/columns/renderPerformerColumns.js
@@ -41,6 +41,7 @@ function renderCancelBtn(
 			buttonType = "confirm";
 		}
 	} else if (
+		requestsType !== "withdraw" &&
 		record.status === "accepted" &&
 		record.request.takerAddr === walletAddress &&
 		isTimeUp(record.request.chooseTimestamp, h24Mc)
@@ -203,7 +204,7 @@ export default function renderPerformerColumns({
 					if (record.request) {
 						return record.request.takerAddr &&
 							record.request.takerAddr === walletAddress &&
-							record.request.statusСode !== requestStatus.complained &&
+							record.request.statusCode !== requestStatus.complained &&
 							record.request.chooseTimestamp ? (
 							<Countdown date={new Date(record.request.chooseTimestamp).getTime() + h24Mc} />
 						) : (
@@ -219,8 +220,11 @@ export default function renderPerformerColumns({
 				render: (text, record, index) => {
 					if (!record.request) {
 						return null;
+					} else if (record.request.statusCode === requestStatus.complained) {
+						return null;
 					}
 					if (record._isDisabled) return "n/a";
+
 					const isConfirmActive =
 						record.request.requestId === activeRequestId && activeAction === aa.confirm;
 
@@ -258,7 +262,8 @@ export default function renderPerformerColumns({
 								record,
 								cancelAcceptedRequest,
 								walletAddress,
-								isCancelAcceptedRequestActive
+								isCancelAcceptedRequestActive,
+								requestsType
 							)}
 						</>
 					);

--- a/src/pages/requests/table/columns/renderPerformerColumns.js
+++ b/src/pages/requests/table/columns/renderPerformerColumns.js
@@ -32,20 +32,45 @@ function renderCancelBtn(
 	let confirmText;
 	let buttonType;
 
-	if (record.status === "accepted" && record.request.takerAddr !== walletAddress) {
-		buttonText = isAnotherSelected ? "Return assets" : "Cancel acceptation";
+	if (record.status === "accepted" && !record.request.takerAddr) {
+		// performer are not selected
+		buttonText = "Cancel acceptation";
 		if (isCancelAcceptedRequestActive) {
 			buttonType = "default";
 		} else {
-			confirmText = isAnotherSelected ? "Sure to return assets?" : "Sure to cancel acceptation?";
+			confirmText = "Sure to cancel acceptation?";
+			buttonType = "confirm";
+		}
+	} else if (record.status === "accepted" && isAnotherSelected && requestsType !== "withdraw") {
+		// another is selected as performer of deposit (for withdraw this doesn't make sense)
+		buttonText = "Return assets";
+		if (isCancelAcceptedRequestActive) {
+			buttonType = "default";
+		} else {
+			confirmText = "Sure to return assets?";
 			buttonType = "confirm";
 		}
 	} else if (
-		requestsType !== "withdraw" &&
 		record.status === "accepted" &&
 		record.request.takerAddr === walletAddress &&
-		isTimeUp(record.request.chooseTimestamp, h24Mc)
+		isTimeUp(record.request.chooseTimestamp, h24Mc) &&
+		requestsType !== "withdraw"
 	) {
+		// deposit request is timed out ?
+		buttonText = "Return assets";
+		if (isCancelAcceptedRequestActive) {
+			buttonType = "default";
+		} else {
+			confirmText = "Sure to return assets?";
+			buttonType = "confirm";
+		}
+	} else if (
+		record.status === "accepted" &&
+		record.request.takerAddr === walletAddress &&
+		record.request.statusCode === requestStatus.rejected &&
+		requestsType !== "withdraw"
+	) {
+		// initiator canceled deposit request after performer was selected
 		buttonText = "Return assets";
 		if (isCancelAcceptedRequestActive) {
 			buttonType = "default";

--- a/src/pages/requests/table/columns/renderPerformerColumns.js
+++ b/src/pages/requests/table/columns/renderPerformerColumns.js
@@ -313,7 +313,8 @@ export default function renderPerformerColumns({
 								performRequest,
 								walletAddress,
 								requestsType,
-								isPerformActive
+								isPerformActive,
+								true
 							)}
 							{renderCancelBtn(
 								record,

--- a/src/pages/requests/table/index.js
+++ b/src/pages/requests/table/index.js
@@ -113,18 +113,23 @@ export function renderPerformBtn(
 	let btn;
 
 	function getButton(requestId) {
+		let btnText;
+		if (requestsType === "deposit" || requestsType === "buy_onyx_cash") {
+			btnText = "Perform Deposit";
+		} else {
+			btnText = "Perform Withdraw";
+		}
+
 		if (isPerformActive) {
 			return (
 				<Button type="primary" loading={true} disabled={true}>
-					{requestsType === "deposit" ? "Perform Deposit" : "Perform"}
+					{btnText}
 				</Button>
 			);
 		} else {
 			return (
 				<Popconfirm title="Sure to perform?" onConfirm={() => performRequest(requestId)}>
-					<Button type="primary">
-						{requestsType === "deposit" ? "Perform Deposit" : "Perform"}
-					</Button>
+					<Button type="primary">{btnText}</Button>
 				</Popconfirm>
 			);
 		}

--- a/src/pages/requests/table/index.js
+++ b/src/pages/requests/table/index.js
@@ -2,6 +2,7 @@ import React from "react";
 import { Input, Button, Icon, Popconfirm } from "antd";
 import { requestStatus, operationMessageStatus } from "api/constants";
 import { h24Mc } from "api/constants";
+import { convertAmountToStr } from "utils/number";
 
 export function handleTableChange({ fetchData, paginationState, setState }) {
 	return function(pagination, filters, sorter) {
@@ -108,16 +109,42 @@ export function renderPerformBtn(
 	performRequest,
 	walletAddress,
 	requestsType,
-	isPerformActive
+	isPerformActive,
+	isPerformerAgent
 ) {
 	let btn;
 
 	function getButton(requestId) {
 		let btnText;
-		if (requestsType === "deposit" || requestsType === "buy_onyx_cash") {
+		let confirmText;
+		if (requestsType === "deposit") {
 			btnText = "Perform Deposit";
+			confirmText = `Are you sure you want to deposit ${convertAmountToStr(
+				record.request.amount,
+				8
+			)} ${record.request.asset} into ${record.sender.firstName} ${
+				record.sender.lastName
+			}'s customer account?`;
+		} else if (requestsType === "buy_onyx_cash") {
+			btnText = "Perform Deposit";
+			confirmText = `Are you sure you want to deposit ${convertAmountToStr(
+				record.request.amount,
+				8
+			)} ${record.request.asset} into ${record.sender.firstName} ${
+				record.sender.lastName
+			}'s Agent/Super agent account?`;
 		} else {
 			btnText = "Perform Withdraw";
+			if (isPerformerAgent) {
+				confirmText = "Are you sure you want to perform the withdrawal request?";
+			} else {
+				confirmText = `Please, confirm you have received ${convertAmountToStr(
+					record.amount,
+					8
+				)} fiat ${record.asset} from ${record.taker.firstName} ${
+					record.taker.lastName
+				}'s Agent account`;
+			}
 		}
 
 		if (isPerformActive) {
@@ -128,7 +155,7 @@ export function renderPerformBtn(
 			);
 		} else {
 			return (
-				<Popconfirm title="Sure to perform?" onConfirm={() => performRequest(requestId)}>
+				<Popconfirm title={confirmText} onConfirm={() => performRequest(requestId)}>
 					<Button type="primary">{btnText}</Button>
 				</Popconfirm>
 			);

--- a/src/pages/requests/table/index.js
+++ b/src/pages/requests/table/index.js
@@ -138,7 +138,7 @@ export function renderPerformBtn(
 			if (isPerformerAgent) {
 				confirmText = "Are you sure you want to perform the withdrawal request?";
 			} else {
-				confirmText = `Please, confirm you have received ${convertAmountToStr(
+				confirmText = `Please confirm you have received ${convertAmountToStr(
 					record.amount,
 					8
 				)} fiat ${record.asset} from ${record.taker.firstName} ${

--- a/src/pages/send-asset/index.js
+++ b/src/pages/send-asset/index.js
@@ -162,7 +162,6 @@ class SendAsset extends Component {
 
 	handleAmountChange = (values, formActions) => async value => {
 		const isEnteredEnoughAmount = this.isEnteredEnoughAmount(value, values.asset_symbol);
-		// fix
 		if (isEnteredEnoughAmount) {
 			this.debouncedGetFee(values.asset_symbol, value);
 		} else {

--- a/src/pages/send-asset/index.js
+++ b/src/pages/send-asset/index.js
@@ -14,7 +14,7 @@ import { debounce } from "lodash";
 import { refreshBalance } from "providers/balanceProvider";
 import AssetsBalance from "components/balance/AssetsBalance";
 import { handleBcError } from "api/network";
-import { checkUserRole } from "api/admin/users";
+import { checkUserRole, isBlockedUser } from "api/admin/users";
 import { roles } from "api/constants";
 import { trimAddress } from "utils";
 
@@ -100,6 +100,15 @@ class SendAsset extends Component {
 						"assets cannot be sent to Agents or Super agents"
 					);
 				}
+			}
+
+			const isReceiverBlocked = await isBlockedUser(values.receiver_address);
+			if (isReceiverBlocked) {
+				formActions.setSubmitting(false);
+				return formActions.setFieldError(
+					"receiver_address",
+					"assets cannot be sent to a blocked account"
+				);
 			}
 
 			const isEnteredEnoughAmount = this.isEnteredEnoughAmount(values.amount, values.asset_symbol);

--- a/src/pages/upgrade-user/index.js
+++ b/src/pages/upgrade-user/index.js
@@ -203,7 +203,7 @@ class UpgradeUser extends Component {
 			return (
 				<div>
 					<Title level={4} style={StepTitleCss}>
-						Purchase OnyxCash.
+						Purchase OnyxCash
 					</Title>
 					<p>
 						Please purchase an amount of OnyxCash equal to{" "}

--- a/src/pages/withdraw/index.js
+++ b/src/pages/withdraw/index.js
@@ -1,6 +1,6 @@
 import React, { Component } from "react";
 import { connect } from "react-redux";
-import { Card, Button, Input, Form, Select, Row, Col, Alert } from "antd";
+import { Card, Button, Input, Form, Select, Row, Col, Alert, Typography, InputNumber } from "antd";
 import { Formik } from "formik";
 import { PageTitle } from "../../components";
 import Actions from "redux/actions";
@@ -23,14 +23,21 @@ import { Link } from "react-router-dom";
 import { createLoadingSelector } from "selectors/loading";
 import { FETCH_SETTLEMENTS_LIST } from "redux/settlements";
 import { getFee } from "../../api/assets";
+import { debounce } from "lodash";
 
+const { Text } = Typography;
 const { Option } = Select;
 
 class Withdraw extends Component {
-	state = {
-		activeRequestsError: false,
-		settlementsError: false,
-	};
+	constructor(props) {
+		super(props);
+		this.debouncedGetFee = debounce(this.debouncedGetFee.bind(this), 500);
+		this.state = {
+			fee: null,
+			activeRequestsError: false,
+			settlementsError: false,
+		};
+	}
 
 	async componentDidMount() {
 		const { getExchangeRates, getSettlementsList } = this.props;
@@ -56,7 +63,7 @@ class Withdraw extends Component {
 		}
 	}
 
-	isEnoughAmount(amount, assetSymbol) {
+	isEnteredEnoughAmount(amount, assetSymbol) {
 		const { exchangeRates } = this.props;
 		const rate = exchangeRates.find(rate => rate.symbol === assetSymbol);
 		const rateUSD = exchangeRates.find(rate => rate.symbol === "oUSD");
@@ -64,7 +71,7 @@ class Withdraw extends Component {
 		return isEnough;
 	}
 
-	async calcMaxAmount(assetSymbol) {
+	async calcMaxAmount(assetSymbol, updateFee) {
 		const { assets } = this.props;
 		if (assets.length) {
 			try {
@@ -80,6 +87,9 @@ class Withdraw extends Component {
 					maxAmount = (maxAmount / (1 + updatedAmountFeePercent)).toFixed(8);
 					updatedFee = (await getFee(assetSymbol, maxAmount.toString(), "withdraw")) / 10 ** 8;
 				}
+				if (updateFee) {
+					this.setState({ fee: updatedFee });
+				}
 				return maxAmount;
 			} catch (e) {
 				showBcError(e.message);
@@ -89,7 +99,7 @@ class Withdraw extends Component {
 	}
 
 	handleMaxAmount = (assetSymbol, setFieldValue) => async e => {
-		const maxAmount = await this.calcMaxAmount(assetSymbol);
+		const maxAmount = await this.calcMaxAmount(assetSymbol, true);
 		setFieldValue("amount", maxAmount);
 	};
 
@@ -101,18 +111,20 @@ class Withdraw extends Component {
 				formActions.setSubmitting(false);
 				return formActions.setFieldError("asset_symbol", "asset is blocked at the moment");
 			}
-			const isEnoughAmount = this.isEnoughAmount(values.amount, values.asset_symbol);
-			if (!isEnoughAmount) {
+			const isEnteredEnoughAmount = this.isEnteredEnoughAmount(values.amount, values.asset_symbol);
+
+			if (!isEnteredEnoughAmount) {
 				formActions.setSubmitting(false);
 				return formActions.setFieldError("amount", "min amount is 1 oUSD");
 			}
 			const maxAmount = await this.calcMaxAmount(values.asset_symbol);
-			if (maxAmount < values.amount) {
+
+			if (Number(maxAmount) < Number(values.amount)) {
 				formActions.setSubmitting(false);
 				return formActions.setFieldError("amount", `max ${maxAmount}`);
 			}
 
-			if (!isBlocked && isEnoughAmount) {
+			if (!isBlocked && isEnteredEnoughAmount) {
 				const res = await createRequest(values, "withdraw");
 				if (!res.error) {
 					showNotification({
@@ -141,9 +153,28 @@ class Withdraw extends Component {
 		setFieldValue("asset_symbol", value);
 	};
 
+	debouncedGetFee(assetSymbol, amount) {
+		getFee(assetSymbol, amount, "send").then(fee => {
+			this.setState({ fee: fee / 10 ** 8 });
+		});
+	}
+
+	handleAmountChange = (values, formActions) => async value => {
+		const isEnteredEnoughAmount = this.isEnteredEnoughAmount(value, values.asset_symbol);
+
+		if (isEnteredEnoughAmount) {
+			this.debouncedGetFee(values.asset_symbol, value);
+		} else {
+			if (this.state.fee) {
+				this.setState({ fee: null });
+			}
+		}
+		formActions.setFieldValue("amount", value);
+	};
+
 	render() {
 		const { assets } = this.props;
-		const { activeRequestsError, settlementsError } = this.state;
+		const { activeRequestsError, settlementsError, fee } = this.state;
 
 		const isFormDisabled = settlementsError || activeRequestsError;
 
@@ -163,7 +194,7 @@ class Withdraw extends Component {
 							if (!values.asset_symbol) {
 								errors.asset_symbol = "required";
 							}
-							if (!values.amount) {
+							if (values.amount === null || values.amount === "") {
 								errors.amount = "required";
 							} else if (values.amount <= 0) {
 								errors.amount = "only positive values are allowed";
@@ -229,15 +260,19 @@ class Withdraw extends Component {
 												help={errors.amount && touched.amount ? errors.amount : ""}
 											>
 												<Input.Group compact style={{ display: "flex" }}>
-													<Input
+													<InputNumber
 														name="amount"
-														type="number"
 														placeholder="Enter an amount"
 														value={values.amount}
-														onChange={handleChange}
+														min={0}
+														step={1}
+														onChange={this.handleAmountChange(values, {
+															setFieldError,
+															setFieldValue,
+														})}
 														onBlur={handleBlur}
 														disabled={isFormDisabled || isSubmitting}
-														step="any"
+														style={{ width: "100%" }}
 													/>
 													<Button
 														onClick={this.handleMaxAmount(values.asset_symbol, setFieldValue)}
@@ -247,6 +282,14 @@ class Withdraw extends Component {
 													</Button>
 												</Input.Group>
 											</Form.Item>
+											{fee && values.amount && (
+												<Text
+													type="secondary"
+													style={{ display: "block", margin: "-12px 0 12px 0" }}
+												>
+													fee will be {fee}
+												</Text>
+											)}
 										</Col>
 									</Row>
 									<TextAligner align="right" mobile="left">


### PR DESCRIPTION
ONXP-1195 - [Gideon][GUI][OnyxCash deposit] Text in notification about fiat payment must be fixed
ONXP-907 - [Gideon][Deposit][Withdraw] Add improvements for Perform button
ONXP-910 - [Blocked Users] It is necessary to remove the possibility of sending assets to a blocked user.
ONXP-796 - [Deposit] Request is sent to blocked agent without error
ONXP-1176 - [Withdraw] Add fee information about withdraw transaction
ONXP-613 - [Registration] Need to display first wallet from .dat file
ONXP-1193 - [Withdraw] Change request status when request was confirmed and choosed
ONXP-1204 - [Gideon][GUI] Link to support email must be displayed for complained requests
ONXP-1177 - [Withdraw] Return assets button must displays for user instread agent and doesn't display when complaint was send
ONXP-1181 - [Withdraw] Add possibity to hide transaction which was confirmed but was not selected