### PR TITLE
added possibility to pass filtering options to PaginatedTable

### DIFF
--- a/src/components/paginated-list/ExchangeHistory.js
+++ b/src/components/paginated-list/ExchangeHistory.js
@@ -49,6 +49,7 @@ function ExchangeHistory(props) {
 				columns={exchangeHistoryColumns}
 				rowKey="trxHast"
 				fetchData={getExchangeHistory}
+				passedOpts={{}}
 				emptyTableMessage={"You haven't performed any exchange transactions yet."}
 				className="exchange-history-table"
 			/>

--- a/src/components/paginated-list/OperationsWidget.js
+++ b/src/components/paginated-list/OperationsWidget.js
@@ -62,6 +62,7 @@ function OperationsWidget(props) {
 				columns={operationHistoryColumns}
 				rowKey="operationId"
 				fetchData={getOperationHistory}
+				passedOpts={{ status: "completed" }}
 				emptyTableMessage="You haven't performed any operations yet."
 			/>
 		</>

--- a/src/components/paginated-list/PaginatedTable.js
+++ b/src/components/paginated-list/PaginatedTable.js
@@ -41,7 +41,7 @@ class PaginatedTable extends Component {
 	fetchTransactionHistory = async (opts = {}, hideLoading = false) => {
 		try {
 			const { pagination } = this.state;
-			const { fetchData } = this.props;
+			const { fetchData, passedOpts } = this.props;
 
 			if (!hideLoading) {
 				this.setState({ loading: true });
@@ -50,6 +50,7 @@ class PaginatedTable extends Component {
 				pageSize: pagination.pageSize,
 				pageNum: pagination.current,
 				...opts,
+				...passedOpts,
 			};
 			const res = await fetchData(params);
 			if (!res.error) {

--- a/src/components/paginated-list/ReferralsList.js
+++ b/src/components/paginated-list/ReferralsList.js
@@ -37,6 +37,7 @@ function ReferralsList(props) {
 				columns={referralsTableColumns}
 				rowKey="addr"
 				fetchData={getReferralsList}
+				passedOpts={{}}
 				emptyTableMessage="You don't have any referrals yet."
 			/>
 		</>

--- a/src/components/paginated-list/RewardedTransactionsList.js
+++ b/src/components/paginated-list/RewardedTransactionsList.js
@@ -31,6 +31,7 @@ function RewardedTransactionsList(props) {
 				columns={referralsTableColumns}
 				rowKey="id"
 				fetchData={getRewardsList}
+				passedOpts={{}}
 				emptyTableMessage="You don't have any rewarded transactions yet."
 			/>
 		</>


### PR DESCRIPTION
ONXP-1202 [Gideon][Transactions list] Canceled requests is displayed in transactions list
- added possibility to pass filtering options to PaginatedTable
- transactions are now filtered by status before displaying on dashboard
