### PR TITLE
fixed logical error with setting default assets

### DIFF
--- a/src/pages/assets-exchange/index.js
+++ b/src/pages/assets-exchange/index.js
@@ -152,7 +152,6 @@ class AssetsExchange extends Component {
 
 		let assetsForBuyData = this.getAssetsForBuyData();
 		let assetsForSellData = this.getAssetsForSellData();
-		console.log(assetsForBuyData, assetsForSellData);
 
 		let defaultAssetToSellName = "";
 		let defaultAssetToBuyName = "";

--- a/src/pages/assets-exchange/index.js
+++ b/src/pages/assets-exchange/index.js
@@ -83,7 +83,6 @@ class AssetsExchange extends Component {
 
 		for (let i in assetsData) {
 			let item = assetsData[i];
-
 			if (type === "buy" && item.buyPrice) {
 				res.push(item);
 			} else if (type === "sell" && item.sellPrice) {
@@ -153,6 +152,7 @@ class AssetsExchange extends Component {
 
 		let assetsForBuyData = this.getAssetsForBuyData();
 		let assetsForSellData = this.getAssetsForSellData();
+		console.log(assetsForBuyData, assetsForSellData);
 
 		let defaultAssetToSellName = "";
 		let defaultAssetToBuyName = "";
@@ -167,7 +167,7 @@ class AssetsExchange extends Component {
 			defaultAssetToBuyName = defaultAssetToBuy.name;
 			selectedCorrectDefaultAssets = true;
 		} else if (user.role === roles.sa) {
-			if (assetsForSellData.length >= 2) {
+			if (assetsForSellData.length >= 1) {
 				const defaultAssetToBuy = assetsForBuyData[0];
 				const defaultAssetToSell = assetsForSellData.find(
 					record => record.name !== defaultAssetToBuy.name


### PR DESCRIPTION
ONXP-1217 [Exchange] "Asset to buy" list is empty for Super agent:
Impact: Since OnyxCash was removed from assets for sell list for superagents, logic of setting default assets should be updated as well, so i updated validation of default assets. Now at least 1 item in asset for sell list is required for form to be unblocked.