### PR TITLE
Bugfix

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -130,6 +130,11 @@ let ClosedOpRequests = Loadable({
 	loading: Loader,
 });
 
+let DevOptions = Loadable({
+	loader: () => import(/* webpackChunkName: "DevOptions" */ "./pages/admin-panel/devOptions"),
+	loading: Loader,
+});
+
 // permissions
 const User = Authorization([roles.c]);
 // const AgentAndSuperAgent = Authorization([roles.a, roles.sa]);
@@ -161,6 +166,7 @@ ActiveOwnWithdrawRequests = All(ActiveOwnWithdrawRequests);
 ClosedOpRequests = All(ClosedOpRequests);
 Deposit = All(Deposit);
 ReferralProgram = All(ReferralProgram);
+DevOptions = AdminAndSuperAdmin(DevOptions);
 
 class App extends Component {
 	componentDidMount() {
@@ -210,6 +216,9 @@ class App extends Component {
 					<Route path="/active-requests/withdraw" exact component={ActiveOwnWithdrawRequests} />
 					<Route path="/closed-requests/deposit" exact component={ClosedOpRequests} />
 					<Route path="/closed-requests/withdraw" exact component={ClosedOpRequests} />
+
+					{/* only for development and testing, should not be rendered in prod */}
+					<Route path="/admin/dev" exact component={DevOptions} />
 				</>
 			);
 		}

--- a/src/api/bc.js
+++ b/src/api/bc.js
@@ -72,7 +72,6 @@ export async function sendTrx(trx, preExec = false, waitNotify = false) {
 }
 
 export async function addSignAndSendTrx(serializedTrx, pk) {
-	console.log("!!");
 	const signedTrx = signTrx(serializedTrx, pk, true);
 	return await timeout(sendTrx(signedTrx, false, true), notifyTimeout);
 }

--- a/src/api/dev-options.js
+++ b/src/api/dev-options.js
@@ -1,0 +1,59 @@
+import { ParameterType } from "ontology-ts-sdk";
+
+import { unlockWalletAccount } from "./wallet";
+import { getStore } from "../store";
+import { resolveContractAddress } from "../redux/contracts";
+import { ContractAddressError } from "../utils/custom-error";
+import { createTrx, sendTrx, addSignAndSendTrx } from "./bc";
+
+import { get } from "lodash";
+
+export async function changeMode(newMode) {
+	const { pk, accountAddress } = await unlockWalletAccount();
+	const store = getStore();
+	const address = await store.dispatch(resolveContractAddress("RequestHolder"));
+	if (!address) {
+		throw new ContractAddressError("Unable to get address of RequestHolder smart-contract");
+	}
+
+	const trx = createTrx({
+		funcName: "ChangeMode",
+		params: [
+			{ label: "caller", type: ParameterType.String, value: "did:onx:" + accountAddress.value },
+			{ label: "keyNo", type: ParameterType.Integer, value: 1 },
+			{
+				label: "mode",
+				type: ParameterType.Int,
+				value: newMode,
+			},
+		],
+		contractAddress: address,
+		accountAddress,
+	});
+
+	return addSignAndSendTrx(trx.serialize(), pk);
+}
+
+export async function getMode(userId) {
+	const store = getStore();
+	const address = await store.dispatch(resolveContractAddress("RequestHolder"));
+	if (!address) {
+		throw new ContractAddressError("Unable to get address of RequestHolder smart-contract");
+	}
+
+	const trx = createTrx({
+		funcName: "GetMode",
+		params: [],
+		contractAddress: address,
+	});
+
+	const res = await sendTrx(trx, true);
+
+	let mode = get(res, "Result.Result", 0);
+	if (mode === "") {
+		mode = 0;
+	} else {
+		mode = parseInt(mode, 16);
+	}
+	return mode;
+}

--- a/src/components/balance/AvailableBalance.js
+++ b/src/components/balance/AvailableBalance.js
@@ -52,7 +52,7 @@ class AvailableBalance extends Component {
 		}
 
 		return (
-			<Text strong style={{ display: "block", margin: "-12px 0px 12px" }}>
+			<Text type="secondary" style={{ display: "block", margin: "-12px 0px 12px" }}>
 				Available balance: {balance} {symbol}
 			</Text>
 		);

--- a/src/components/layout/DropdownMenu.js
+++ b/src/components/layout/DropdownMenu.js
@@ -73,6 +73,8 @@ const DropdownMenu = ({ logOut, user }) => {
 				</Menu.Item>
 			</Menu>
 		);
+	} else {
+		return null;
 	}
 
 	return (

--- a/src/components/layout/menu/AdminMenu.js
+++ b/src/components/layout/menu/AdminMenu.js
@@ -54,6 +54,15 @@ class AdminMenu extends Component {
 						</Link>
 					</Menu.Item>
 				</SubMenu>
+
+				{process.env.REACT_APP_TAG !== "prod" && (
+					<Menu.Item key="/admin/dev">
+						<Link to="/admin/dev" className="ant-menu-item-content">
+							<Icon type="tool" />
+							<span>Dev options</span>
+						</Link>
+					</Menu.Item>
+				)}
 			</Menu>
 		);
 	}

--- a/src/components/modals/AddSettlementModal.js
+++ b/src/components/modals/AddSettlementModal.js
@@ -49,10 +49,10 @@ class AddSettlementModal extends Component {
 					validate={values => {
 						let errors = {};
 						if (!values.account_number) {
-							errors.account_number = "required";
+							errors.account_number = "Required";
 						}
 						if (!values.account_name) {
-							errors.account_name = "required";
+							errors.account_name = "Required";
 						}
 						return errors;
 					}}

--- a/src/components/modals/ConfirmEmail.js
+++ b/src/components/modals/ConfirmEmail.js
@@ -80,7 +80,7 @@ class ConfirmEmailModal extends Component {
 							validate={values => {
 								let errors = {};
 								if (!values.email) {
-									errors.email = "required";
+									errors.email = "Required";
 								} else if (!isEmailValid(values.email)) {
 									errors.email = "Enter valid email";
 								}

--- a/src/components/modals/Registration.js
+++ b/src/components/modals/Registration.js
@@ -108,21 +108,21 @@ class RegistrationModal extends Component {
 					validate={values => {
 						let errors = {};
 						if (!values.firstName) {
-							errors.firstName = "required";
+							errors.firstName = "Required";
 						} else if (values.firstName.length < 2) {
-							errors.firstName = "min length 2";
+							errors.firstName = "Min length 2";
 						} else if (!isLatinChars(values.firstName)) {
 							errors.firstName = "First name must contain only Latin letters";
 						}
 						if (!values.lastName) {
-							errors.lastName = "required";
+							errors.lastName = "Required";
 						} else if (values.lastName.length < 2) {
-							errors.lastName = "min length 2";
+							errors.lastName = "Min length 2";
 						} else if (!isLatinChars(values.lastName)) {
 							errors.lastName = "Last name must contain only Latin letters";
 						}
 						if (!values.country_id) {
-							errors.country_id = "required";
+							errors.country_id = "Required";
 						}
 						if (values.referral_wallet.length !== 0 && !isBase58Address(values.referral_wallet)) {
 							errors.referral_wallet = "Referral wallet address should be in base58 format";

--- a/src/components/modals/admin/AddNewAsset.js
+++ b/src/components/modals/admin/AddNewAsset.js
@@ -52,10 +52,10 @@ class AddNewAsset extends Component {
 						validate={({ assets_symbol, asset_name }) => {
 							let errors = {};
 							if (!assets_symbol) {
-								errors.assets_symbol = "required";
+								errors.assets_symbol = "Required";
 							}
 							if (!asset_name) {
-								errors.asset_name = "required";
+								errors.asset_name = "Required";
 							}
 							return errors;
 						}}

--- a/src/components/modals/admin/ReasonToRejectUpgrade.js
+++ b/src/components/modals/admin/ReasonToRejectUpgrade.js
@@ -28,7 +28,7 @@ class ReasonToRejectUpgradeModal extends Component {
 						validate={values => {
 							let errors = {};
 							if (!values.reason) {
-								errors.reason = "required";
+								errors.reason = "Required";
 							}
 							return errors;
 						}}

--- a/src/components/modals/admin/SetExchangeRates.js
+++ b/src/components/modals/admin/SetExchangeRates.js
@@ -62,20 +62,20 @@ class SetExchangeRates extends Component {
 						validate={({ assets_buy, asset_sell }) => {
 							let errors = {};
 							if (!assets_buy) {
-								errors.assets_buy = "required";
+								errors.assets_buy = "Required";
 							} else if (!+assets_buy) {
-								errors.assets_buy = "only positive numbers allowed";
+								errors.assets_buy = "Only positive numbers allowed";
 							} else if (assets_buy <= 0) {
-								errors.assets_buy = "only positive numbers allowed";
+								errors.assets_buy = "Only positive numbers allowed";
 							}
 							if (!asset_sell) {
-								errors.asset_sell = "required";
+								errors.asset_sell = "Required";
 							} else if (!+asset_sell) {
-								errors.asset_sell = "only positive numbers allowed";
+								errors.asset_sell = "Only positive numbers allowed";
 							} else if (asset_sell >= assets_buy) {
-								errors.asset_sell = "sell can't be bigger than buy";
+								errors.asset_sell = "Sell can't be bigger than buy";
 							} else if (asset_sell <= 0) {
-								errors.asset_sell = "only positive numbers allowed";
+								errors.asset_sell = "Only positive numbers allowed";
 							}
 
 							return errors;

--- a/src/components/modals/wallet/CreateWalletModal.js
+++ b/src/components/modals/wallet/CreateWalletModal.js
@@ -77,7 +77,7 @@ class CreateWalletModal extends Component {
 		const { setWallet } = this.props;
 
 		if (generatedMnemonics !== mnemonics) {
-			formActions.setFieldError("mnemonics", "mnemonic don't match");
+			formActions.setFieldError("mnemonics", "Mnemonic don't match");
 		} else {
 			// save wallet
 			setWallet(wallet);
@@ -134,9 +134,9 @@ class CreateWalletModal extends Component {
 								validate={({ password, password_confirm, terms_confirm }) => {
 									let errors = {};
 									if (!password) {
-										errors.password = "required";
+										errors.password = "Required";
 									} else if (!password_confirm) {
-										errors.password_confirm = "required";
+										errors.password_confirm = "Required";
 									} else {
 										errors = samePassword({ password, password_confirm });
 									}
@@ -264,9 +264,9 @@ class CreateWalletModal extends Component {
 								validate={({ mnemonics }) => {
 									let errors = {};
 									if (!mnemonics) {
-										errors.mnemonics = "required";
+										errors.mnemonics = "Required";
 									} else if (!isMnemonicsValid(mnemonics)) {
-										errors.mnemonics = "mnemonic phrase is not valid";
+										errors.mnemonics = "Mnemonic phrase is not valid";
 									}
 									return errors;
 								}}

--- a/src/components/modals/wallet/ImportWalletModal.js
+++ b/src/components/modals/wallet/ImportWalletModal.js
@@ -98,7 +98,7 @@ class ImportWalletModal extends Component {
 			});
 		} catch (error) {
 			if (error === 53000) {
-				formActions.setFieldError("password", "account's password is not correct");
+				formActions.setFieldError("password", "Account's password is not correct");
 			}
 		} finally {
 			formActions.setSubmitting(false);
@@ -112,7 +112,7 @@ class ImportWalletModal extends Component {
 		if (isLt1M) {
 			this.setState({ fileList, fileReadError: "" });
 		} else {
-			this.setState({ fileList: [], fileReadError: "wallet file is not valid" });
+			this.setState({ fileList: [], fileReadError: "Wallet file is not valid" });
 		}
 	};
 
@@ -136,12 +136,12 @@ class ImportWalletModal extends Component {
 						}
 					});
 				} catch (e) {
-					this.setState({ fileReadError: "wallet file is not valid" });
+					this.setState({ fileReadError: "Wallet file is not valid" });
 				}
 			};
 			reader.readAsText(file);
 		} else {
-			this.setState({ fileReadError: "wallet file is not valid" });
+			this.setState({ fileReadError: "Wallet file is not valid" });
 		}
 
 		return false;
@@ -211,10 +211,10 @@ class ImportWalletModal extends Component {
 											let errors = {};
 
 											if (!password) {
-												errors.password = "required";
+												errors.password = "Required";
 											}
 											if (!wallet_account_address) {
-												errors.wallet_account_address = "required";
+												errors.wallet_account_address = "Required";
 											}
 											return errors;
 										}}
@@ -326,14 +326,14 @@ class ImportWalletModal extends Component {
 										validate={({ mnemonics, password, password_confirm }) => {
 											let errors = {};
 											if (!mnemonics) {
-												errors.mnemonics = "required";
+												errors.mnemonics = "Required";
 											} else if (!isMnemonicsValid(mnemonics)) {
-												errors.mnemonics = "mnemonic phrase is not valid";
+												errors.mnemonics = "Mnemonic phrase is not valid";
 											}
 											if (!password) {
-												errors.password = "required";
+												errors.password = "Required";
 											} else if (!password_confirm) {
-												errors.password_confirm = "required";
+												errors.password_confirm = "Required";
 											} else {
 												errors = samePassword({ password, password_confirm });
 											}
@@ -424,14 +424,14 @@ class ImportWalletModal extends Component {
 										validate={({ pk, password, password_confirm }) => {
 											let errors = {};
 											if (!pk) {
-												errors.pk = "required";
+												errors.pk = "Required";
 											} else if (!isPkValid(pk)) {
 												errors.pk = "Private key is not valid";
 											}
 											if (!password) {
-												errors.password = "required";
+												errors.password = "Required";
 											} else if (!password_confirm) {
-												errors.password_confirm = "required";
+												errors.password_confirm = "Required";
 											} else {
 												errors = samePassword({ password, password_confirm });
 											}

--- a/src/components/modals/wallet/UnlockWalletModal.js
+++ b/src/components/modals/wallet/UnlockWalletModal.js
@@ -29,7 +29,7 @@ class UnlockWalletModal extends Component {
 			hideModal();
 		} catch (error) {
 			if (error === 53000) {
-				formActions.setFieldError("password", "account's password is not correct");
+				formActions.setFieldError("password", "Account's password is not correct");
 			}
 		} finally {
 			formActions.setSubmitting(false);
@@ -59,7 +59,7 @@ class UnlockWalletModal extends Component {
 						validate={({ password }) => {
 							let errors = {};
 							if (!password) {
-								errors.password = "required";
+								errors.password = "Required";
 							}
 
 							return errors;

--- a/src/pages/admin-panel/devOptions/index.js
+++ b/src/pages/admin-panel/devOptions/index.js
@@ -1,0 +1,61 @@
+import React from "react";
+import { Radio, Typography, Card, Spin, Icon } from "antd";
+import { getMode, changeMode } from "api/dev-options";
+import { handleBcError } from "api/network";
+const { Text } = Typography;
+
+const loadingIcon = <Icon type="loading" style={{ fontSize: 24 }} spin />;
+
+const DevOptions = () => {
+	const [modeCode, setModeNumber] = React.useState(0);
+	const [isLoading, setLoading] = React.useState(false);
+
+	async function fetchModeValue() {
+		try {
+			let response = await getMode();
+			setModeNumber(response);
+		} catch (e) {
+			handleBcError(e);
+		}
+	}
+
+	React.useEffect(() => {
+		fetchModeValue();
+	}, []);
+
+	const onChange = async e => {
+		const newModeValue = e.target.value;
+		try {
+			setModeNumber(newModeValue);
+			setLoading(true);
+			await changeMode(newModeValue);
+		} catch (e) {
+			handleBcError(e);
+		} finally {
+			setLoading(false);
+		}
+	};
+
+	return (
+		<Card>
+			<Text level={4} style={{ display: "block", marginBottom: 12 }}>
+				Choose Request holder mode
+			</Text>
+			<div>
+				<Radio.Group
+					onChange={onChange}
+					options={[
+						{ label: "main", value: 0 },
+						{ label: "test", value: 1 },
+						{ label: "dev", value: 2 },
+					]}
+					value={modeCode}
+					disabled={isLoading}
+				/>
+				{isLoading && <Spin indicator={loadingIcon} />}
+			</div>
+		</Card>
+	);
+};
+
+export default DevOptions;

--- a/src/pages/admin-panel/investments/Block.js
+++ b/src/pages/admin-panel/investments/Block.js
@@ -26,10 +26,10 @@ class BlockInvestor extends Component {
 						validate={({ user_name, user_password }) => {
 							let errors = {};
 							if (!user_name) {
-								errors.user_name = "required";
+								errors.user_name = "Required";
 							}
 							if (!user_password) {
-								errors.user_password = "required";
+								errors.user_password = "Required";
 							}
 							return errors;
 						}}

--- a/src/pages/admin-panel/investments/GetUnclaimed.js
+++ b/src/pages/admin-panel/investments/GetUnclaimed.js
@@ -28,10 +28,10 @@ class GetUnclaimed extends Component {
 						validate={values => {
 							let errors = {};
 							if (!values.user_name) {
-								errors.user_name = "required";
+								errors.user_name = "Required";
 							}
 							if (!values.user_password) {
-								errors.user_password = "required";
+								errors.user_password = "Required";
 							}
 							return errors;
 						}}

--- a/src/pages/admin-panel/investments/SetAmount.js
+++ b/src/pages/admin-panel/investments/SetAmount.js
@@ -33,10 +33,10 @@ class SetAmount extends Component {
 						validate={({ user_name, user_password, user_confirm_password, amount }) => {
 							let errors = {};
 							if (!user_name) {
-								errors.user_name = "required";
+								errors.user_name = "Required";
 							}
 							if (!amount) {
-								errors.amount = "required";
+								errors.amount = "Required";
 							}
 							if (amount && amount < 0) {
 								errors.amount = "Amount must be more than 0";
@@ -45,10 +45,10 @@ class SetAmount extends Component {
 								errors.amount = "Amount must be more than 0";
 							}
 							if (!user_password) {
-								errors.user_password = "required";
+								errors.user_password = "Required";
 							}
 							if (!user_confirm_password) {
-								errors.user_confirm_password = "required";
+								errors.user_confirm_password = "Required";
 							}
 							if (
 								user_password &&

--- a/src/pages/admin-panel/investments/Unblock.js
+++ b/src/pages/admin-panel/investments/Unblock.js
@@ -28,10 +28,10 @@ class UnblockInvestor extends Component {
 						validate={values => {
 							let errors = {};
 							if (!values.user_name) {
-								errors.user_name = "required";
+								errors.user_name = "Required";
 							}
 							if (!values.user_password) {
-								errors.user_password = "required";
+								errors.user_password = "Required";
 							}
 							return errors;
 						}}

--- a/src/pages/deposit/index.js
+++ b/src/pages/deposit/index.js
@@ -1,6 +1,6 @@
 import React, { Component } from "react";
 import { connect } from "react-redux";
-import { Card, Button, Input, Form, Select, Typography, Row, Col, Alert } from "antd";
+import { Card, Button, Input, Form, Select, Row, Col, Alert } from "antd";
 import { Formik } from "formik";
 import { PageTitle } from "../../components";
 import Actions from "../../redux/actions";
@@ -20,7 +20,6 @@ import {
 import { GasCompensationError, SendRawTrxError } from "utils/custom-error";
 
 const { Option } = Select;
-const { Text } = Typography;
 
 class Deposit extends Component {
 	state = {
@@ -66,13 +65,13 @@ class Deposit extends Component {
 				isBlocked = await isAssetBlocked(values.asset_symbol);
 				if (isBlocked) {
 					formActions.setSubmitting(false);
-					return formActions.setFieldError("asset_symbol", "asset is blocked at the moment");
+					return formActions.setFieldError("asset_symbol", "Asset is blocked at the moment");
 				}
 
 				isEnoughAmount = this.isEnoughAmount(values.amount, values.asset_symbol);
 				if (!isEnoughAmount) {
 					formActions.setSubmitting(false);
-					return formActions.setFieldError("amount", "min amount is 1 USD");
+					return formActions.setFieldError("amount", "Min amount is 1 USD");
 				}
 			}
 
@@ -126,16 +125,16 @@ class Deposit extends Component {
 						validate={values => {
 							let errors = {};
 							if (!values.asset_symbol) {
-								errors.asset_symbol = "required";
+								errors.asset_symbol = "Required";
 							}
 							if (!values.amount) {
-								errors.amount = "required";
+								errors.amount = "Required";
 							} else if (values.amount <= 0) {
-								errors.amount = "only positive values are allowed";
+								errors.amount = "Only positive values are allowed";
 							} else if ((user.role === roles.a || user.role === roles.sa) && values.amount < 1) {
-								errors.amount = `min amount is 1 ${onyxCashSymbol}`;
+								errors.amount = `Min amount is 1 ${onyxCashSymbol}`;
 							} else if (countDecimals(values.amount) > 8) {
-								errors.amount = "max number of decimal places is 8";
+								errors.amount = "Max number of decimal places is 8";
 							}
 
 							return errors;

--- a/src/pages/deposit/index.js
+++ b/src/pages/deposit/index.js
@@ -235,7 +235,7 @@ class Deposit extends Component {
 									{activeRequestsError && (
 										<Alert
 											style={{ marginTop: 16 }}
-											message="Limit of active requests(10) is exceeded. To create new requests you should resolve some of the old ones"
+											message="Limit of active deposit and withdraw requests (10) is exceeded. To create new requests you should resolve some of the old ones."
 											type="error"
 										/>
 									)}

--- a/src/pages/deposit/index.js
+++ b/src/pages/deposit/index.js
@@ -189,15 +189,6 @@ class Deposit extends Component {
 													<Input name="asset_symbol" disabled={true} value={values.asset_symbol} />
 												)}
 											</Form.Item>
-											{user.role === roles.c ? (
-												<Text
-													type="secondary"
-													style={{ display: "block", margin: "-12px 0 12px 0" }}
-												>
-													{!activeRequestsError &&
-														"Only selected fiat currency can be sent to the agent"}
-												</Text>
-											) : null}
 										</Col>
 
 										<Col lg={12} md={24}>
@@ -237,6 +228,14 @@ class Deposit extends Component {
 											type="error"
 										/>
 									)}
+
+									{user.role === roles.c && !activeRequestsError ? (
+										<Alert
+											style={{ marginTop: 16 }}
+											message="Only selected fiat currency can be sent to the agent"
+											type="info"
+										/>
+									) : null}
 								</form>
 							);
 						}}

--- a/src/pages/requests/ActiveOwnDepositRequests.js
+++ b/src/pages/requests/ActiveOwnDepositRequests.js
@@ -5,6 +5,7 @@ import ActiveRequests from "pages/requests/ActiveRequests";
 import { createLoadingSelector } from "selectors/loading";
 import { push } from "connected-react-router";
 import { getOpRequests, GET_OPERATION_REQUESTS } from "redux/requests";
+import { disableRequest } from "redux/requests";
 
 const loadingSelector = createLoadingSelector([GET_OPERATION_REQUESTS]);
 function mapStateToProps(state, ownProps) {
@@ -22,7 +23,7 @@ var ActiveOwnDepositRequests = compose(
 	withRouter,
 	connect(
 		mapStateToProps,
-		{ push, getOpRequests }
+		{ push, getOpRequests, disableRequest }
 	)
 )(ActiveRequests);
 

--- a/src/pages/requests/ActiveOwnWithdrawRequests.js
+++ b/src/pages/requests/ActiveOwnWithdrawRequests.js
@@ -5,6 +5,7 @@ import ActiveRequests from "pages/requests/ActiveRequests";
 import { createLoadingSelector } from "selectors/loading";
 import { push } from "connected-react-router";
 import { getOpRequests, GET_OPERATION_REQUESTS } from "redux/requests";
+import { disableRequest } from "redux/requests";
 
 const loadingSelector = createLoadingSelector([GET_OPERATION_REQUESTS]);
 function mapStateToProps(state, ownProps) {
@@ -22,7 +23,7 @@ var ActiveOwnWithdrawRequests = compose(
 	withRouter,
 	connect(
 		mapStateToProps,
-		{ push, getOpRequests: getOpRequests }
+		{ push, getOpRequests: getOpRequests, disableRequest }
 	)
 )(ActiveRequests);
 

--- a/src/pages/requests/table/columns/renderInitiatorColumns.js
+++ b/src/pages/requests/table/columns/renderInitiatorColumns.js
@@ -158,9 +158,7 @@ export default function renderInitiatorColumns({
 						>
 							{getPerformerName(record.takerAddr, record.taker)}
 						</Button>
-					) : (
-						"n/a"
-					);
+					) : null;
 				},
 			},
 			{
@@ -174,9 +172,7 @@ export default function renderInitiatorColumns({
 								onClick={e => showUserSettlementsModal(record.taker.id)}
 							/>
 						</Tooltip>
-					) : (
-						"n/a"
-					);
+					) : null;
 				},
 			},
 			{
@@ -185,9 +181,7 @@ export default function renderInitiatorColumns({
 					if (record._isDisabled) return "n/a";
 					return record.takerAddr && record.chooseTimestamp && record.status !== "complained" ? (
 						<Countdown date={new Date(record.chooseTimestamp).getTime() + h24Mc} />
-					) : (
-						"n/a"
-					);
+					) : null;
 				},
 			},
 			{

--- a/src/pages/requests/table/columns/renderInitiatorColumns.js
+++ b/src/pages/requests/table/columns/renderInitiatorColumns.js
@@ -253,15 +253,15 @@ export default function renderInitiatorColumns({
 								isCancelRequestActive
 							)}
 
+							{/* Perform withdraw request */}
+							{requestsType === "withdraw" &&
+								renderPerformBtn(record, performRequest, null, requestsType, isPerformActive)}
+
 							{/* Complain on request */}
 							{record.takerAddr &&
 								record.chooseTimestamp &&
 								!is24hOver(record.chooseTimestamp) &&
 								renderComplainButton(record, handleComplain, isComplainActive)}
-
-							{/* Perform withdraw request */}
-							{requestsType === "withdraw" &&
-								renderPerformBtn(record, performRequest, null, requestsType, isPerformActive)}
 						</>
 					);
 				},

--- a/src/pages/requests/table/columns/renderPerformerColumns.js
+++ b/src/pages/requests/table/columns/renderPerformerColumns.js
@@ -259,9 +259,7 @@ export default function renderPerformerColumns({
 										onClick={e => showUserSettlementsModal(record.sender.id)}
 									/>
 								</Tooltip>
-							) : (
-								"n/a"
-							);
+							) : null;
 						},
 				  }
 				: { className: "hidden-column" },
@@ -275,9 +273,7 @@ export default function renderPerformerColumns({
 							record.request.statusCode !== requestStatus.complained &&
 							record.request.chooseTimestamp ? (
 							<Countdown date={new Date(record.request.chooseTimestamp).getTime() + h24Mc} />
-						) : (
-							"n/a"
-						);
+						) : null;
 					} else {
 						return null;
 					}

--- a/src/pages/requests/table/columns/renderPerformerColumns.js
+++ b/src/pages/requests/table/columns/renderPerformerColumns.js
@@ -113,7 +113,7 @@ function renderConfirmBtn(record, isConfirmActive, confirmRequest) {
 		} else {
 			return (
 				<Popconfirm
-					title="Sure to accept?"
+					title="Sure?"
 					onConfirm={() =>
 						confirmRequest(
 							record.request.requestId,

--- a/src/pages/requests/table/columns/renderPerformerColumns.js
+++ b/src/pages/requests/table/columns/renderPerformerColumns.js
@@ -35,11 +35,11 @@ function renderCancelBtn(
 
 	if (record.status === "accepted" && !record.request.takerAddr) {
 		// performer are not selected
-		buttonText = "Cancel acceptation";
+		buttonText = "Cancel confirmation";
 		if (isCancelAcceptedRequestActive) {
 			buttonType = "default";
 		} else {
-			confirmText = "Sure to cancel acceptation?";
+			confirmText = "Sure to cancel confirmation?";
 			buttonType = "confirm";
 		}
 	} else if (record.status === "accepted" && isAnotherSelected && requestsType !== "withdraw") {

--- a/src/pages/send-asset/index.js
+++ b/src/pages/send-asset/index.js
@@ -97,7 +97,7 @@ class SendAsset extends Component {
 					formActions.setSubmitting(false);
 					return formActions.setFieldError(
 						"receiver_address",
-						"assets cannot be sent to Agents or Super agents"
+						"Assets cannot be sent to Agents or Super agents"
 					);
 				}
 			}
@@ -107,14 +107,14 @@ class SendAsset extends Component {
 				formActions.setSubmitting(false);
 				return formActions.setFieldError(
 					"receiver_address",
-					"assets cannot be sent to a blocked account"
+					"Assets cannot be sent to a blocked account"
 				);
 			}
 
 			const isEnteredEnoughAmount = this.isEnteredEnoughAmount(values.amount, values.asset_symbol);
 			if (!isEnteredEnoughAmount) {
 				formActions.setSubmitting(false);
-				return formActions.setFieldError("amount", "min amount is 1 oUSD");
+				return formActions.setFieldError("amount", "Min amount is 1 oUSD");
 			}
 			const isEnteredAmountOverBalance = await this.isEnteredAmountOverBalance(
 				values.amount,
@@ -123,7 +123,7 @@ class SendAsset extends Component {
 			if (isEnteredAmountOverBalance) {
 				const maxAmount = await this.calcMaxAmount(values.asset_symbol);
 				formActions.setSubmitting(false);
-				return formActions.setFieldError("amount", `max ${maxAmount}`);
+				return formActions.setFieldError("amount", `Max amount is ${maxAmount}`);
 			}
 			if (isEnteredEnoughAmount && !isEnteredAmountOverBalance) {
 				await sendAsset(values);
@@ -205,19 +205,19 @@ class SendAsset extends Component {
 						validate={values => {
 							let errors = {};
 							if (!values.receiver_address) {
-								errors.receiver_address = "required";
+								errors.receiver_address = "Required";
 							} else if (!isBase58Address(values.receiver_address)) {
 								errors.receiver_address = "Recipient's address should be in base58 format";
 							}
 							if (!values.asset_symbol) {
-								errors.asset_symbol = "required";
+								errors.asset_symbol = "Required";
 							}
 							if (values.amount === null || values.amount === "") {
-								errors.amount = "required";
+								errors.amount = "Required";
 							} else if (values.amount <= 0) {
-								errors.amount = "only positive values are allowed";
+								errors.amount = "Only positive values are allowed";
 							} else if (countDecimals(values.amount) > 8) {
-								errors.amount = "max number of decimal places is 8";
+								errors.amount = "Max number of decimal places is 8";
 							}
 
 							return errors;

--- a/src/pages/withdraw/index.js
+++ b/src/pages/withdraw/index.js
@@ -322,6 +322,13 @@ class Withdraw extends Component {
 											type="error"
 										/>
 									)}
+									{assets.length && (
+										<Alert
+											style={{ marginTop: 16 }}
+											message="The fiat payment from the agent can be sent only in the selected currency."
+											type="info"
+										/>
+									)}
 								</form>
 							);
 						}}

--- a/src/pages/withdraw/index.js
+++ b/src/pages/withdraw/index.js
@@ -318,7 +318,7 @@ class Withdraw extends Component {
 									{activeRequestsError && (
 										<Alert
 											style={{ marginTop: 16 }}
-											message="Limit of active requests(10) is exceeded. To create new requests you should resolve some of the old ones"
+											message="Limit of active deposit and withdraw requests (10) is exceeded. To create new requests you should resolve some of the old ones."
 											type="error"
 										/>
 									)}

--- a/src/pages/withdraw/index.js
+++ b/src/pages/withdraw/index.js
@@ -109,19 +109,19 @@ class Withdraw extends Component {
 			const isBlocked = await isAssetBlocked(values.asset_symbol);
 			if (isBlocked) {
 				formActions.setSubmitting(false);
-				return formActions.setFieldError("asset_symbol", "asset is blocked at the moment");
+				return formActions.setFieldError("asset_symbol", "Asset is blocked at the moment");
 			}
 			const isEnteredEnoughAmount = this.isEnteredEnoughAmount(values.amount, values.asset_symbol);
 
 			if (!isEnteredEnoughAmount) {
 				formActions.setSubmitting(false);
-				return formActions.setFieldError("amount", "min amount is 1 oUSD");
+				return formActions.setFieldError("amount", "Min amount is 1 oUSD");
 			}
 			const maxAmount = await this.calcMaxAmount(values.asset_symbol);
 
 			if (Number(maxAmount) < Number(values.amount)) {
 				formActions.setSubmitting(false);
-				return formActions.setFieldError("amount", `max ${maxAmount}`);
+				return formActions.setFieldError("amount", `Max amount is ${maxAmount}`);
 			}
 
 			if (!isBlocked && isEnteredEnoughAmount) {
@@ -191,14 +191,14 @@ class Withdraw extends Component {
 						validate={values => {
 							let errors = {};
 							if (!values.asset_symbol) {
-								errors.asset_symbol = "required";
+								errors.asset_symbol = "Required";
 							}
 							if (values.amount === null || values.amount === "") {
-								errors.amount = "required";
+								errors.amount = "Required";
 							} else if (values.amount <= 0) {
-								errors.amount = "only positive values are allowed";
+								errors.amount = "Only positive values are allowed";
 							} else if (countDecimals(values.amount) > 8) {
-								errors.amount = "max number of decimal places is 8";
+								errors.amount = "Max number of decimal places is 8";
 							}
 							return errors;
 						}}

--- a/src/pages/withdraw/index.js
+++ b/src/pages/withdraw/index.js
@@ -322,7 +322,7 @@ class Withdraw extends Component {
 											type="error"
 										/>
 									)}
-									{assets.length && (
+									{assets.length && !activeRequestsError && (
 										<Alert
 											style={{ marginTop: 16 }}
 											message="The fiat payment from the agent can be sent only in the selected currency."


### PR DESCRIPTION
ONXP-1110 - [Complaints][Pre-prod] Test mode without timers for requests must be implemented
ONXP-1224 - [Profile] The site is crashed after deletion of the account
ONXP-1220 - [Requests] Closed Assets and OnyxCash requests are not displayed for initiators
ONXP-1215 - [Gideon][GUI] Text on pop-up window with request confirmation must be changed
ONXP-1214 - [GUI] Text about limit of requests must be improved
ONXP-1213 - [Send][GUI] Error message about recipient should start with upper case letter
ONXP-1196 - [Gideon][GUI][Requests] Empty space without "n/a" must be displayed for requests without timer
ONXP-1190 - [Withdraw] Add information about selected assets when creating withdraw
ONXP-1180 - [Withdraw] Improve buttons Complain and cancel acceptation