### PR TITLE
ONXP-1354 [Exchange][Edge][GUI] A scroll is displayed in thet table with balances on Exchange page, if there are a lot free space for it

### DIFF
--- a/src/pages/assets-exchange/index.js
+++ b/src/pages/assets-exchange/index.js
@@ -645,7 +645,6 @@ class AssetsExchange extends Component {
 								columns={assetsColumns}
 								dataSource={this.state.assetsData}
 								pagination={false}
-								className="ovf-y-auto--18rem"
 								locale={{ emptyText: "No assets available in the system at the moment." }}
 							/>
 						</Col>


### PR DESCRIPTION
Changed the table height on Exchange page to auto

![1354](https://user-images.githubusercontent.com/47985373/65016765-b67e5880-d92d-11e9-97a9-f0e49401cb38.jpg)

![1354-1](https://user-images.githubusercontent.com/47985373/65016770-b9794900-d92d-11e9-9aa9-ac11c1aee103.jpg)
