### PR TITLE
ONXP-1705 [Mob_app] Table with settlement data goes outside of pop-up in admin panel

### DIFF
--- a/src/components/layout/index.js
+++ b/src/components/layout/index.js
@@ -101,20 +101,22 @@ class Layout extends Component {
 			<AntLayout className="main-layout">
 				<MyContext.Provider value={activeBreakPoint}>
 					<Header toggleSidebar={this.toggleSidebar} isSidebarCollapsed={isSideBarCollapsed} />
-				</MyContext.Provider>
-				<AntLayout className={isSideBarCollapsed ? "content-wrapper collapsed" : "content-wrapper"}>
-					<Sidebar
-						collapsed={isSideBarCollapsed}
-						xsDevise={activeBreakPoint === "xs"}
-						user={user}
-						location={location}
-						toggleSidebar={this.toggleSidebar}
-					/>
-					<AntLayout>
-						<MainContent>{children}</MainContent>
-						<Footer />
+					<AntLayout
+						className={isSideBarCollapsed ? "content-wrapper collapsed" : "content-wrapper"}
+					>
+						<Sidebar
+							collapsed={isSideBarCollapsed}
+							xsDevise={activeBreakPoint === "xs"}
+							user={user}
+							location={location}
+							toggleSidebar={this.toggleSidebar}
+						/>
+						<AntLayout>
+							<MainContent>{children}</MainContent>
+							<Footer />
+						</AntLayout>
 					</AntLayout>
-				</AntLayout>
+				</MyContext.Provider>
 			</AntLayout>
 		);
 	}


### PR DESCRIPTION
Adapted the table to the small screens: now cards are showing on the small screens
I also fixed the bug when to open the information about the user who has a settlement account, and then to open the information about the user who does not have a settlement account, the information of the first user was displayed
![image](https://user-images.githubusercontent.com/50625592/68203283-232cdf80-ffce-11e9-96c8-773a4b026a97.png)
